### PR TITLE
Bump to ver. 0.1.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,16 @@
+0.1.2 / 2021-04-02
+==================
+
+  * Initialize environmental and parsing properties
+  * Downgrade eslint dependency to v6.8.0 and extend recommended ruleset
+  * Override any ESLint recommended rule
+
+0.1.1 / 2021-03-30
+==================
+
+  * Initialize rules set to follow the ESLint recommended set
+
+0.1.0 / 2021-03-30
+==================
+
+  * Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "eslint-config-aargh",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^6.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-aargh",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Iakovos Papadopoulos <iakopap@gmail.com>",
   "description": "A strongly opinionated ESLint configuration for seriously taken cartoonish development.",
   "keywords": [


### PR DESCRIPTION
0.1.2 / 2021-04-02
==================

  * Initialize environmental and parsing properties
  * Downgrade eslint dependency to v6.8.0 and extend recommended ruleset
  * Override any ESLint recommended rule